### PR TITLE
feat: add encryption service settings as secrets

### DIFF
--- a/swarm-stack/docker-compose.yml
+++ b/swarm-stack/docker-compose.yml
@@ -47,6 +47,9 @@ services:
     secrets:
       - source: doppler-forms_appsettings.Secret.json
         target: appsettings.Secret.json
+      - EncryptionSettings__InitVectorAsAsciiString
+      - EncryptionSettings__SaltValueAsAsciiString
+      - EncryptionSettings__Password
     networks:
       - sites
     deploy:
@@ -66,3 +69,9 @@ secrets:
     file: ./secrets/doppler-docker-playground/appsettings.Secret.json
   doppler-forms_appsettings.Secret.json:
     file: ./secrets/doppler-forms/appsettings.Secret.json
+  EncryptionSettings__InitVectorAsAsciiString:
+    file: ./secrets/EncryptionSettings/InitVectorAsAsciiString
+  EncryptionSettings__SaltValueAsAsciiString:
+    file: ./secrets/EncryptionSettings/SaltValueAsAsciiString
+  EncryptionSettings__Password:
+    file: ./secrets/EncryptionSettings/Password

--- a/swarm-stack/secrets/EncryptionSettings/InitVectorAsAsciiString
+++ b/swarm-stack/secrets/EncryptionSettings/InitVectorAsAsciiString
@@ -1,0 +1,1 @@
+{{Replace this value in destination server}}

--- a/swarm-stack/secrets/EncryptionSettings/Password
+++ b/swarm-stack/secrets/EncryptionSettings/Password
@@ -1,0 +1,1 @@
+{{Replace this value in destination server}}

--- a/swarm-stack/secrets/EncryptionSettings/SaltValueAsAsciiString
+++ b/swarm-stack/secrets/EncryptionSettings/SaltValueAsAsciiString
@@ -1,0 +1,1 @@
+{{Replace this value in destination server}}


### PR DESCRIPTION
Not a big deal, because I cannot store sensitive data in this public repository.

But, at least it is clear what will need to apply in our production server.

I have still pending moving these things to an independent private repository.

