### PR TITLE
DW-103: reverse proxy for webapp

### DIFF
--- a/sites-proxy/Dockerfile
+++ b/sites-proxy/Dockerfile
@@ -6,6 +6,7 @@ ARG version=unknown
 RUN echo $version > /usr/share/nginx/html/version.txt
 
 EXPOSE 80/tcp
+EXPOSE 443/tcp
 
 CMD ["/bin/sh", "-c", "exec nginx -g 'daemon off;';"]
 

--- a/sites-proxy/conf.d/app.fromdoppler.com.conf
+++ b/sites-proxy/conf.d/app.fromdoppler.com.conf
@@ -6,4 +6,17 @@ server {
         proxy_pass  http://doppler-webapp;
     }
 
+    return 301 https://$server_name$request_uri;
+
+}
+server {
+        listen                  443 default_server ssl;
+        server_name             app.fromdoppler.com;
+        ssl_certificate         /run/secrets/site.crt;
+        ssl_certificate_key     /run/secrets/site.key;
+
+        location / {
+            proxy_pass  http://doppler-webapp;
+        }
+    
 }

--- a/sites-proxy/conf.d/play.fromdoppler.com.conf
+++ b/sites-proxy/conf.d/play.fromdoppler.com.conf
@@ -6,4 +6,17 @@ server {
         proxy_pass  http://doppler-docker-playground;
     }
 
+    return 301 https://$server_name$request_uri;
+
+}
+server {
+        listen                  443 default_server ssl;
+        server_name             play.fromdoppler.com;
+        ssl_certificate         /run/secrets/site.crt;
+        ssl_certificate_key     /run/secrets/site.key;
+
+        location / {
+            proxy_pass  http://doppler-docker-playground;
+        }
+    
 }

--- a/swarm-stack/docker-compose.yml
+++ b/swarm-stack/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       mode: replicated
       restart_policy:
         condition: on-failure
+    secrets:
+      - site.crt
+      - site.key
   
   doppler-webapp:
     image: fromdoppler/doppler-webapp:production-v1
@@ -76,3 +79,7 @@ secrets:
     file: ./secrets/EncryptionSettings/SaltValueAsAsciiString
   EncryptionSettings__Password:
     file: ./secrets/EncryptionSettings/Password
+  site.crt:
+    file: ./secrets/site.crt
+  site.key:
+    file: ./secrets/site.key

--- a/swarm-stack/docker-compose.yml
+++ b/swarm-stack/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - sites
     ports:
       - 80:80
+      - 443:443
     deploy:
       replicas: 2
       mode: replicated

--- a/swarm-stack/secrets/site.crt
+++ b/swarm-stack/secrets/site.crt
@@ -1,0 +1,1 @@
+{insert valid certificate here}

--- a/swarm-stack/secrets/site.key
+++ b/swarm-stack/secrets/site.key
@@ -1,0 +1,1 @@
+{insert valid certificate key here}

--- a/swarm-stack/tests.http
+++ b/swarm-stack/tests.http
@@ -12,6 +12,11 @@ GET http://127.0.0.1/version.txt
 
 ###
 GET http://play.fromdoppler.com
+
+###
+GET http://play.fromdoppler.com
+###
+GET https://play.fromdoppler.com
 ###
 GET http://play.fromdoppler.com/version.txt
 


### PR DESCRIPTION
Added signing for webapp in reverse proxy.
- Exposed 443 port for proxy
- Added certificates as secrets in configuration
- Modified conf for webapp an playground for local testing 