### PR TITLE
Use the right certificate for dopplerpages.com

### DIFF
--- a/sites-proxy/conf.d/dopplerpages.com.conf
+++ b/sites-proxy/conf.d/dopplerpages.com.conf
@@ -2,13 +2,23 @@
 server {
     listen         80;
     server_name    dopplerpages.com;
+    server_name    www.dopplerpages.com;
 
-    return 301 https://$server_name$request_uri;
+    return 301 https://www.dopplerpages.com$request_uri;
+}
+
+server {
+    listen         443 ssl;
+    server_name    dopplerpages.com;
+    ssl_certificate         /run/secrets/certificates__dopplerpages.com-20201202.crt;
+    ssl_certificate_key     /run/secrets/certificates__dopplerpages.com-20201202.key;
+
+    return 301 https://www.dopplerpages.com$request_uri;
 }
 
 server {
         listen                  443 ssl;
-        server_name             dopplerpages.com;
+        server_name             www.dopplerpages.com;
         ssl_certificate         /run/secrets/certificates__dopplerpages.com-20201202.crt;
         ssl_certificate_key     /run/secrets/certificates__dopplerpages.com-20201202.key;
 

--- a/sites-proxy/conf.d/dopplerpages.com.conf
+++ b/sites-proxy/conf.d/dopplerpages.com.conf
@@ -9,8 +9,8 @@ server {
 server {
         listen                  443 ssl;
         server_name             dopplerpages.com;
-        ssl_certificate         /run/secrets/certificates__fromdoppler.com-20201108.crt;
-        ssl_certificate_key     /run/secrets/certificates__fromdoppler.com-20201108.key;
+        ssl_certificate         /run/secrets/certificates__dopplerpages.com-20201202.crt;
+        ssl_certificate_key     /run/secrets/certificates__dopplerpages.com-20201202.key;
 
         location / {
             proxy_set_header Host $host;

--- a/swarm-stack/docker-compose.yml
+++ b/swarm-stack/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       restart_policy:
         condition: on-failure
     secrets:
+      - certificates__dopplerpages.com-20201202.crt
+      - certificates__dopplerpages.com-20201202.key
       - certificates__fromdoppler.com-20201108.crt
       - certificates__fromdoppler.com-20201108.key
       # Obsolete:
@@ -95,3 +97,8 @@ secrets:
     file: ./secrets/certificates/fromdoppler.com-20201108.crt
   certificates__fromdoppler.com-20201108.key:
     file: ./secrets/certificates/fromdoppler.com-20201108.key
+  # Certificates dopplerpages.com
+  certificates__dopplerpages.com-20201202.crt:
+    file: ./secrets/certificates/dopplerpages.com-20201202.crt
+  certificates__dopplerpages.com-20201202.key:
+    file: ./secrets/certificates/dopplerpages.com-20201202.key

--- a/swarm-stack/secrets/certificates/dopplerpages.com-20201202.crt
+++ b/swarm-stack/secrets/certificates/dopplerpages.com-20201202.crt
@@ -1,0 +1,1 @@
+{insert valid certificate here}

--- a/swarm-stack/secrets/certificates/dopplerpages.com-20201202.key
+++ b/swarm-stack/secrets/certificates/dopplerpages.com-20201202.key
@@ -1,0 +1,1 @@
+{insert valid certificate key here}


### PR DESCRIPTION
Hi @juanasas, @CarlosPintos, @elsupergomez, @cbernat, and team,

This is to configure the right certificate in `dopplerpages.com`, before merging it, I need to add the right certificate in `doppler-swarm-devops` repo and update the file name with the right expiration time.

Could you review it?

TODO:

- [x] Rename the files with the right expiration date.
- [x] Merge MakingSense/doppler-swarm-devops#3 before this